### PR TITLE
Allow booting server without email credentials during development

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,7 @@ Run the following commands:
 ```bash
 # Install dependencies
 $ bundler install
-# Set credentials. This will open up an editor. Add the following to the end before closing:
-#   mailer:
-#     gmail_account: gmail@gmail.gmail
-#     password: gmail
+# Set credentials. This will open up an editor that you can exit to continue.
 $ rm config/credentials.yml.enc && rails credentials:edit
 # Create, migrate, and seed database
 $ rails db:create db:migrate db:seed

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,8 +43,8 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     :address              => "smtp.gmail.com",
     :port                 => 587,
-    :user_name            => Rails.application.credentials.mailer[:gmail_account],
-    :password             => Rails.application.credentials.mailer[:gmail_app_password],
+    :user_name            => Rails.application.credentials.mailer&[:gmail_account],
+    :password             => Rails.application.credentials.mailer&[:gmail_app_password],
     :authentication       => "plain",
     :enable_starttls_auto => true
   }


### PR DESCRIPTION
This makes updates to the development config and README based on the conversation from [here](https://github.com/Jess-White/boilerplate_rebuild_app/pull/56#discussion_r637595157).