### PR TITLE
Save user to org when creating

### DIFF
--- a/app/controllers/api/organizations_controller.rb
+++ b/app/controllers/api/organizations_controller.rb
@@ -11,7 +11,10 @@ class Api::OrganizationsController < ApplicationController
   end
 
   def create
-    @organization = Organization.create!(name: params[:name])
+    @organization = Organization.create!(
+      name: params[:name],
+      users: [current_user],
+    )
     render "show.json.jb", status: 201
   end
 

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -160,6 +160,24 @@ describe Api::OrganizationsController do
         ),
       )
     end
+
+    it 'creates new organization with user that created it' do
+      chidi = User.create!({
+        email: 'chidi@good.place',
+        password: 'chidi',
+        first_name: "Chidi",
+        last_name: "Anagonye",
+      })
+
+      set_auth_header(jwt(chidi))
+
+      expect {
+        post :create, :params => { "name" => "The Good Place" }
+      }.to change(Organization, :count)
+       .and change(OrganizationUser, :count)
+
+      expect(Organization.last().name).to eq "The Good Place"
+    end
   end
 
   describe 'GET /organizations/:organization_id' do


### PR DESCRIPTION
I noticed creating an organization does not automatically add the authenticated user to that organization. To make less work for the client, I added that to the controller with some tests.