### PR TITLE
Replace byebug dependency with ruby/debug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,7 @@ gem 'jwt'
 gem 'bootsnap', '>= 1.4.2', require: false
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'debug', '~> 1.6'
   gem 'dotenv-rails'
   gem 'rspec-rails'
   gem 'rubocop', '~> 1.31', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,10 +63,12 @@ GEM
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     builder (3.2.4)
-    byebug (11.1.1)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
+    debug (1.6.2)
+      irb (>= 1.3.6)
+      reline (>= 0.3.1)
     diff-lcs (1.4.4)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -115,6 +117,9 @@ GEM
       ffi-compiler (>= 1.0, < 2.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    io-console (0.5.11)
+    irb (1.4.1)
+      reline (>= 0.3.0)
     jb (0.7.1)
       multi_json
     json (2.6.2)
@@ -194,6 +199,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.5.0)
+    reline (0.3.1)
+      io-console (~> 0.5)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -269,7 +276,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
-  byebug
+  debug (~> 1.6)
   dotenv-rails
   factory_bot_rails (~> 6.2)
   faker (~> 2.19)


### PR DESCRIPTION
## 🤺 Summary
<!-- Describe the changes being introduced, providing any necessary context. Screenshots are welcome! -->
Small dependency switch here. [Ruby/debug](https://github.com/ruby/debug) offers additional functionality compared to byebug and requires less additional setup.

## 📝 Checklist
<!-- Check steps as necessary - this list is a reminder -->
* [x] Are tests & linter passing?
* [x] Are reviews assigned to this PR?

## 🧶 Steps to run

Add breakpoints by adding the following code:

```ruby
require 'debug'
debugger
```