### PR TITLE
Add password reset token to link query param in email

### DIFF
--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,6 +1,5 @@
 <p>Hi <%= @user.first_name %>,</p>
 <p>You are receiving this email because you have requested a password reset for your Boilerplate account.</p>
-<p>Please use this code to reset your password: <%= @user.password_reset_token %></p>
 <p>This code will expire one hour from password reset request.</p>
-<p>To reset your password please enter your code in the form <%= link_to "here", "#{Rails.env.development? ? "http" : "https"}://#{ENV.fetch('FRONTEND_ORIGIN')}/reset_password" %>.</p>
+<p>To reset your password please click <%= link_to "here", "#{Rails.env.development? ? "http" : "https"}://#{ENV.fetch('FRONTEND_ORIGIN')}/reset_password?token=#{@user.password_reset_token}" %>.</p>
 <p>If you did not request your password to be reset please ignore this email and your password will stay as it is.</p>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,5 +1,5 @@
 <p>Hi <%= @user.first_name %>,</p>
 <p>You are receiving this email because you have requested a password reset for your Boilerplate account.</p>
 <p>This code will expire one hour from password reset request.</p>
-<p>To reset your password please click <%= link_to "here", "#{Rails.env.development? ? "http" : "https"}://#{ENV.fetch('FRONTEND_ORIGIN')}/reset_password?token=#{@user.password_reset_token}" %>.</p>
+<p>To reset your password please click <%= link_to "here", "#{Rails.env.development? ? "http" : "https"}://#{ENV.fetch('FRONTEND_ORIGIN')}/reset_password?token=#{@user.password_reset_token}&email=#{@user.email}" %>.</p>
 <p>If you did not request your password to be reset please ignore this email and your password will stay as it is.</p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -4,6 +4,6 @@ You are receiving this email because you have requested a password reset for you
 
 This code will expire one hour from password reset request.
 
-To reset your password please click here: <%= "#{Rails.env.development? ? "http" : "https"}://#{ENV.fetch('FRONTEND_ORIGIN')}/reset_password?token=#{@user.password_reset_token}" %>.
+To reset your password please click here: <%= "#{Rails.env.development? ? "http" : "https"}://#{ENV.fetch('FRONTEND_ORIGIN')}/reset_password?token=#{@user.password_reset_token}&email=#{@user.email}" %>.
 
 If you did not request your password to be reset please ignore this email and your password will stay as it is.

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -2,10 +2,8 @@ Hi <%= @user.first_name %>,
 
 You are receiving this email because you have requested a password reset for your Boilerplate account.
 
-Please use this code to reset your password: <%= @user.password_reset_token %>
-
 This code will expire one hour from password reset request.
 
-To reset your password please enter your code in the form here: <%= "#{Rails.env.development? ? "http" : "https"}://#{ENV.fetch('FRONTEND_ORIGIN')}/reset_password" %>.
+To reset your password please click here: <%= "#{Rails.env.development? ? "http" : "https"}://#{ENV.fetch('FRONTEND_ORIGIN')}/reset_password?token=#{@user.password_reset_token}" %>.
 
 If you did not request your password to be reset please ignore this email and your password will stay as it is.


### PR DESCRIPTION
## 🤺 Summary
<!-- Describe the changes being introduced, providing any necessary context. Screenshots are welcome! -->
Apart of Jess-White/boilerplate#400

This updates the reset password template to move the token to be inside the url.

## 📝 Checklist
<!-- Check steps as necessary - this list is a reminder -->
* [x] Are tests & linter passing?
* [x] Are relevant tickets linked to this PR?
* [x] Are reviews assigned to this PR?

## 🔬 Steps to test
1. See testing steps in https://github.com/Jess-White/boilerplate/pull/416